### PR TITLE
templates: Clarify the purpose of this website

### DIFF
--- a/templates/root/index.html
+++ b/templates/root/index.html
@@ -25,8 +25,15 @@
 <div id="content">
 <div class="box">
 	<p>
-To install Haiku, we offer <strong>stable</strong> release builds as well as <strong>nightly</strong>
-builds which are continually built by a cluster of dedicated machines from the <a href="http://cgit.haiku-os.org/haiku/">latest Haiku source code</a>.
+To install Haiku, we offer <strong>stable</strong> release builds, as well as <strong>nightly</strong>
+builds. The <strong>nightly builds</strong> are continually built by a cluster of dedicated machines from the
+<a href="http://cgit.haiku-os.org/haiku/">latest Haiku source code</a> and published every few hours, whereas
+the <strong>stable</strong> builds are intended for everyday use and are released roughly yearly.
+	</p>
+	<p>
+The <strong>nightly</strong> release builds can be found on this website.
+If you wish to use a <strong>stable</strong> release build, you can find our stable builds
+<a href="https://www.haiku-os.org/get-haiku/">here</a>.
 	</p>
 	</div>
 <!--


### PR DESCRIPTION
Downloading Haiku can get confusing. The following two screenshots display the results of the search term "`download haiku`" on Google and DuckDuckGo.

![2021-09-21_13-08](https://user-images.githubusercontent.com/30193966/134160386-9120058a-026b-4de0-b130-825884b9f7c8.png)

![2021-09-21_13-09](https://user-images.githubusercontent.com/30193966/134160465-72391b94-85ef-481c-84c2-af17673bbb01.png)
.

When I was just starting out, I also got very confused about what was the right place to download Haiku from, and the lack of back-links made it even more confusing. With this change, I hope to at least clarify that https://download.haiku-os.org is meant for nightly builds, as well as better illustrate the difference between nightly and stable builds and where the user can get them from.